### PR TITLE
finishes transactions find_all

### DIFF
--- a/app/controllers/api/v1/payments/search_controller.rb
+++ b/app/controllers/api/v1/payments/search_controller.rb
@@ -1,5 +1,9 @@
 class Api::V1::Payments::SearchController < ApplicationController
 
+  def index
+    render json: Payment.where(payment_params)
+  end
+
   def show
     render json: Payment.find_by(payment_params)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
 
       resources :payments, path: 'transactions', only: [:index, :show, :create] do
           collection do
-            get '/find', to: 'payments/search#show', as: 'transactions'
+            get '/find', to: 'payments/search#show'
+            get '/find_all', to: 'payments/search#index'
           end
         end
 

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -61,7 +61,7 @@ describe "merchants API" do
     expect{Merchant.find(merchant.id)}.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  xit "finds a merchant by its name" do
+  it "finds a merchant by its name" do
     data_merchant = Fabricate(:merchant)
 
     get "/api/v1/merchants/find?name=#{data_merchant.name}"
@@ -73,7 +73,7 @@ describe "merchants API" do
     expect(merchant["name"]).to eq("#{data_merchant.name}")
   end
 
-    it "finds a merchant by its name, case insensitive" do
+  it "finds a merchant by its name, case insensitive" do
     data_merchant = Fabricate(:merchant, name: "We The Best")
 
     get "/api/v1/merchants/find?name=we the best"
@@ -83,8 +83,9 @@ describe "merchants API" do
     merchant = JSON.parse(response.body)
 
     expect(merchant["name"]).to eq("We The Best")
+  end
 
-  it "can find all customers by providing name" do
+  it "can find all merchants by providing name" do
     data_merchant_1, data_merchant_2 = Fabricate.times(2, :merchant)
 
     get "/api/v1/merchants/find_all?name=#{data_merchant_1.name}"

--- a/spec/requests/api/v1/payments_request_spec.rb
+++ b/spec/requests/api/v1/payments_request_spec.rb
@@ -36,7 +36,7 @@ describe "payments API" do
     expect(payment["id"]).to eq(data_payment.id)
   end
 
-    it "finds a payment by its id" do
+  it "finds a payment by its id" do
     data_payment = Fabricate(:payment)
 
     get "/api/v1/transactions/find?id=#{data_payment.id}"
@@ -46,6 +46,30 @@ describe "payments API" do
     payment = JSON.parse(response.body)
 
     expect(payment["id"]).to eq(data_payment.id)
+  end
+
+  it "can find all payments by providing an invoice_id" do
+    data_payment_1, data_payment_2 = Fabricate.times(2, :payment)
+
+    get "/api/v1/transactions/find_all?id=#{data_payment_1.id}"
+
+    expect(response).to be_success
+
+    transaction_1 = JSON.parse(response.body).first
+
+    expect(transaction_1["id"]).to eq(data_payment_1.id)
+  end
+
+  xit "can find all payments by providing a date" do
+    data_payment_1, data_payment_2 = Fabricate.times(2, :payment, credit_card_expiration_date: "2017-03-14")
+
+    get "/api/v1/transactions/find_all?credit_card_expiration_date=#{data_payment_1.credit_card_expiration_date}"
+
+    expect(response).to be_success
+
+    transaction_1 = JSON.parse(response.body).first
+
+    expect(transaction_1["credit_card_expiration_date"]).to eq(data_payment_1.credit_card_expiration_date)
   end
 
 end


### PR DESCRIPTION
the routes work still! but I removed the "as: transactions" because that was the routes helper, and we don't need it... it was getting a conflict. 